### PR TITLE
fix: Added the actual build step

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,6 +25,8 @@ jobs:
           node-version: lts/*
       - run: npm clean-install
       - run: npm audit signatures
+      - name: Build
+        run: 'npm run build:production'
       # pinned version updated automatically by Renovate.
       # details at https://semantic-release.gitbook.io/semantic-release/usage/installation#global-installation
       - run: npm run semantic-release

--- a/.npmignore
+++ b/.npmignore
@@ -5,6 +5,8 @@ lib
 .editorconfig
 .eslintrc.cjs
 .prettierrc
+CODE_OF_CONDUCT.md
+CODE_OF_CONDUCT.md
 jest.config.json
 LICENSE
 README.md
@@ -13,4 +15,4 @@ test
 .vscode
 CHANGELOG.md
 tsconfig.*
-renovate.json
+scrutinizer.yml


### PR DESCRIPTION
The default semantic-release workflow doesn't build the package because it's written in JS. This one is TS - so it needs to be built beforehand