### PR TITLE
Fixed ignore and exclude file naming and priority

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ You can also use the `include` option which works in the same manner.
 #### Notes
 
  * Include and exclude options are not mutually exclusive so you can use both.
- * Plugin also looks for `.distinclude` and `.distexclude` files which take precedence over the options set in the plugin.
+ * Plugin also looks for `.distinclude` and `.distexclude` / `.distignore` files which take precedence over the options set in the plugin.
  * By default we exclude a lot of build artifacts and files which are not needed in the package. You can see the full list in [constants.ts](lib/constants.ts).
 
 ### Examples

--- a/lib/utils/copy-files.ts
+++ b/lib/utils/copy-files.ts
@@ -24,7 +24,9 @@ function remapGlobs(workDir: string, includePath: string): string {
  * @returns       Array of globs to include
  */
 export function getInclude(workDir: string, files?: string[]): string[] {
-  const include = [...new Set(files ?? getFileArray(workDir, '.distinclude'))];
+  const include = [
+    ...new Set(getFileArray(workDir, '.distinclude') ?? files ?? []),
+  ];
 
   return include.length !== 0 ? include : ['**/*'];
 }
@@ -40,7 +42,10 @@ export function getIgnore(workDir: string, files?: string[]): string[] {
   return [
     ...new Set([
       ...DEFAULT_EXCLUDES,
-      ...(files ?? getFileArray(workDir, '.distignore')),
+      ...(getFileArray(workDir, '.distexclude') ??
+        getFileArray(workDir, '.distignore') ??
+        files ??
+        []),
     ]),
   ]
     .filter(

--- a/lib/utils/get-file-array.ts
+++ b/lib/utils/get-file-array.ts
@@ -1,16 +1,19 @@
 import fs from 'fs-extra';
 import path from 'node:path';
 
-export function getFileArray(workDir: string, fileToRead: string): string[] {
+export function getFileArray(
+  workDir: string,
+  fileToRead: string,
+): null | string[] {
   try {
     const filesinFile = fs
-      .readFileSync(path.resolve(path.join(workDir, fileToRead)), 'utf8')
-      .split('\n')
-      .filter((file) => file !== '')
-      .map((file) => file.trim());
+      .readFileSync(path.resolve(path.join(workDir, fileToRead)), 'utf8') // Read the file from the workDir
+      .split('\n') // Split the file into an array of lines
+      .map((file) => file.trim()) // Trim each line
+      .filter((file) => file !== '' && !file.startsWith('#')); // Remove empty lines and comments
 
     return [...new Set([...filesinFile])];
   } catch (err) {
-    return [];
+    return null;
   }
 }

--- a/test/0-corner-cases.spec.ts
+++ b/test/0-corner-cases.spec.ts
@@ -9,7 +9,7 @@ import { PluginConfig } from '../lib/classes/plugin-config.class.js';
 describe('Corner cases affecting releases', () => {
   it('Should fail to read non-existant file', () => {
     try {
-      const files = getFileArray('/test', 'non-existant-file.txt');
+      const files = getFileArray('/test', 'non-existant-file.txt') ?? [];
       expect(files).toEqual([]);
     } catch (err) {}
   });
@@ -87,7 +87,7 @@ describe('Corner cases affecting releases', () => {
       'vendor',
     ]);
     const ignore1 = DEFAULT_EXCLUDES;
-    const include2 = getInclude(workDir);
+    const include2 = getInclude(workDir, ['dist-test.php']);
     const ignore2 = getIgnore(workDir);
     const expected = ['dist-test.php', 'test1.php', 'vendor'].sort();
 

--- a/test/fixtures/dist-test/.distinclude
+++ b/test/fixtures/dist-test/.distinclude
@@ -1,1 +1,0 @@
-dist-test.php


### PR DESCRIPTION
.distinclude and .distexclude priorities weren't set properly - precedence is now set in accordance with readme

Closes #165 