### PR TITLE
Variable Readme path

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -9,3 +9,6 @@ end_of_line = lf
 charset = utf-8
 trim_trailing_whitespace = true
 insert_final_newline = true
+
+[*.md]
+trim_trailing_whitespace = false

--- a/README.md
+++ b/README.md
@@ -74,16 +74,17 @@ If you have other variables which need to have the version replaced, you can add
 
 If you need any further processing of the package files, next release version will be output to `/tmp/wp-release/VERSION` file, if the `withVersionFile` option is set to `true`.
 
-> **Warning**
+> [!IMPORTANT]
 > Version in your plugin / theme must be set to 0.0.0 for this plugin to work
 
 ### Assets
 If your package is on [wp.org](https://wordpress.org) repository, you might have assets (screenshots, banners, logos) which you want to include in the assets file. Plugin respects the Codex, and expects those to be in ``.wordpress-org/assets`` folder. Main theme screenshot should be named ``screenshot`` and should be there as well.
 
 ### Readme
-readme.txt is a special Markdown file needed for packages on [wp.org](https://wordpress.org) to work. It needs to be in the `.wordpress-org` folder. Plugin will automatically replace the version in the file if the `withReadme` option is set to `true`.
+readme.txt is a special Markdown file needed for packages on [wp.org](https://wordpress.org) to work. It can be in the `.wordpress-org` folder, or in the repository root.  
+Plugin will automatically replace the version in the file if the `withReadme` option is set to `true`.
 
-> ** Warning**
+> [!WARNING]
 > Version in your readme.txt must also be set to 0.0.0 for this plugin to work
 
 ### Include / Exclude

--- a/lib/prepare.ts
+++ b/lib/prepare.ts
@@ -33,7 +33,12 @@ export async function prepare(
   }
 
   if (config.withReadme) {
-    files.push('.wordpress-org/readme.txt');
+    const readmePath = ['.wordpress-org/readme.txt', 'readme.txt'].reduce(
+      (acc, p) => (fs.existsSync(path.join(workDir, p)) ? p : acc),
+      undefined,
+    );
+
+    readmePath && files.push(readmePath);
   }
 
   errors.push(

--- a/test/2-prepare-plugin.spec.ts
+++ b/test/2-prepare-plugin.spec.ts
@@ -108,6 +108,28 @@ describe('Package preparation - cusom work directory', () => {
     expect(readme).toMatch(/Stable tag: 1\.0\.0/);
   });
 
+  it('Should change the readme.txt version in the rootdir', async () => {
+    await prepare(
+      {
+        type: 'plugin',
+        slug: 'root-readme',
+        path: './test/fixtures/root-readme',
+        copyFiles: true,
+        withReadme: true,
+        releasePath,
+        workDir,
+      },
+      contexts.prepareContext,
+    );
+
+    const readme = fs.readFileSync(
+      path.join(getWorkDir(workDir), 'root-readme/readme.txt'),
+      'utf8',
+    );
+
+    expect(readme).toMatch(/Stable tag: 1\.0\.0/);
+  });
+
   it('Should work with empty assets', async () => {
     await prepare(
       {

--- a/test/fixtures/root-readme/readme.txt
+++ b/test/fixtures/root-readme/readme.txt
@@ -1,0 +1,10 @@
+=== Plugin with Readme ===
+Contributors: oblakstudio, seebeen
+Donate link: https://srbizasrbe.org
+Tags: serbia
+Requires at least: 5.6
+Tested up to: 6.1
+Requires PHP: 7.3
+Stable tag: 0.0.0
+License: GPLv2 or later
+License URI: http://www.gnu.org/licenses/gpl-2.0.html

--- a/test/fixtures/root-readme/root-readme.php
+++ b/test/fixtures/root-readme/root-readme.php
@@ -1,0 +1,5 @@
+<?php
+/**
+ * Plugin Name: Plugin One
+ * Version: 0.0.0
+ */


### PR DESCRIPTION
Implements the option to have the wp.org readme.txt in the root directory.

Fixes #166 