### PR TITLE
fix: Version replacing

### DIFF
--- a/lib/utils/replace-versions.ts
+++ b/lib/utils/replace-versions.ts
@@ -14,7 +14,7 @@ export async function replaceVersions(
   try {
     const results = await rif.replaceInFile({
       files: files.map((file) => path.join(workDir, file)),
-      from: currentVersion,
+      from: new RegExp(currentVersion, 'g'),
       to: nextVersion,
     });
 

--- a/test/2-prepare-plugin.spec.ts
+++ b/test/2-prepare-plugin.spec.ts
@@ -40,6 +40,11 @@ describe('Package preparation - cusom work directory', () => {
       },
       contexts.prepareContext,
     );
+    expect(
+      fs
+        .readFileSync(path.join(releasePath, 'plugin1', 'plugin1.php'), 'utf8')
+        .toString(),
+    ).not.toMatch(/0\.0\.0/);
   });
 
   it('Should fail on invalid plugin version', async () => {

--- a/test/fixtures/plugin1/plugin1.php
+++ b/test/fixtures/plugin1/plugin1.php
@@ -3,3 +3,5 @@
  * Plugin Name: Plugin One
  * Version: 0.0.0
  */
+
+define('MY_VERSION', '0.0.0');


### PR DESCRIPTION
Due to non-global regex, versions were replaced only once per file. This commit fixes the issue