### PR TITLE
Fix/asset-publish

### DIFF
--- a/lib/publish.ts
+++ b/lib/publish.ts
@@ -29,7 +29,7 @@ export async function publish(
     const zipResult = config.withAssets
       ? await execa(
           zipCommand,
-          ['-qjr', path.join(releaseDir, `assets.zip`), assetDir],
+          ['-qr', path.join(releaseDir, `assets.zip`), '.'],
           {
             cwd: assetDir,
             timeout: 30 * 1000,

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,6 +23,7 @@
       "devDependencies": {
         "@babel/core": "7.24.7",
         "@babel/preset-env": "7.24.7",
+        "@types/adm-zip": "^0.5.5",
         "@types/fs-extra": "11.0.4",
         "@types/jest": "29.5.12",
         "@types/node": "20.14.7",
@@ -31,6 +32,7 @@
         "@types/sinon": "17.0.3",
         "@typescript-eslint/eslint-plugin": "6.21.0",
         "@typescript-eslint/parser": "6.21.0",
+        "adm-zip": "^0.5.16",
         "babel-jest": "29.7.0",
         "eslint": "8.56.0",
         "eslint-config-prettier": "9.1.0",
@@ -3611,6 +3613,15 @@
       "dev": true,
       "license": "(Unlicense OR Apache-2.0)"
     },
+    "node_modules/@types/adm-zip": {
+      "version": "0.5.5",
+      "resolved": "https://registry.npmjs.org/@types/adm-zip/-/adm-zip-0.5.5.tgz",
+      "integrity": "sha512-YCGstVMjc4LTY5uK9/obvxBya93axZOVOyf2GSUulADzmLhYE45u2nAssCs/fWBs1Ifq5Vat75JTPwd5XZoPJw==",
+      "dev": true,
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
       "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
@@ -4084,6 +4095,15 @@
       "license": "MIT",
       "peerDependencies": {
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
+    "node_modules/adm-zip": {
+      "version": "0.5.16",
+      "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.5.16.tgz",
+      "integrity": "sha512-TGw5yVi4saajsSEgz25grObGHEUaDrniwvA2qwSC060KfqGPdglhvPMA2lPIoxs3PQIItj2iag35fONcQqgUaQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=12.0"
       }
     },
     "node_modules/agent-base": {

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
   "devDependencies": {
     "@babel/core": "7.24.7",
     "@babel/preset-env": "7.24.7",
+    "@types/adm-zip": "^0.5.5",
     "@types/fs-extra": "11.0.4",
     "@types/jest": "29.5.12",
     "@types/node": "20.14.7",
@@ -54,6 +55,7 @@
     "@types/sinon": "17.0.3",
     "@typescript-eslint/eslint-plugin": "6.21.0",
     "@typescript-eslint/parser": "6.21.0",
+    "adm-zip": "^0.5.16",
     "babel-jest": "29.7.0",
     "eslint": "8.56.0",
     "eslint-config-prettier": "9.1.0",

--- a/test/2-prepare-plugin.spec.ts
+++ b/test/2-prepare-plugin.spec.ts
@@ -212,17 +212,22 @@ describe('Package preparation - default work directory', () => {
       contexts.prepareContext,
     );
 
-    const assets = fs.readdirSync(path.join(releasePath, 'assets'));
+    const assets = new Set(
+      fs.readdirSync(path.join(releasePath, 'assets'), {
+        recursive: true,
+      }) as string[],
+    );
 
-    expect(assets).toHaveLength(5);
-    expect(assets.sort()).toStrictEqual(
-      [
+    expect([...assets]).toHaveLength(6);
+    expect(assets).toEqual(
+      new Set([
         'blueprints',
+        'blueprints/blueprint.json',
         'banner-low.jpg',
         'banner-high.jpg',
         'screenshot-1.jpg',
         'screenshot-2.jpg',
-      ].sort(),
+      ]),
     );
   });
 });

--- a/test/3-publish-plugin.spec.ts
+++ b/test/3-publish-plugin.spec.ts
@@ -8,6 +8,7 @@ import { replaceVersions } from '../lib/utils/replace-versions.js';
 import { success } from '../lib/success.js';
 import SemanticReleaseError from '@semantic-release/error';
 import { publish } from '../lib/publish.js';
+import AdmZip, { IZipEntry } from 'adm-zip';
 
 const pluginConfig: PluginConfig = {
   type: 'plugin',
@@ -21,12 +22,37 @@ const pluginConfig: PluginConfig = {
   workDir: 'publish',
 };
 
-let releasePath: string;
+let wDir: string;
 const env = process.env;
 
+function readZip(dir: string, file: string, pfx: RegExp = /.^/): Set<string> {
+  return new Set(
+    new AdmZip(path.join(dir, file))
+      .getEntries()
+      .map(({ entryName }) => entryName.replace(pfx, '').replace(/\/$/, ''))
+      .filter((e) => e !== '' && (pfx.source == '.^' || !e.match(/\//))),
+  );
+}
+
+function readDir(
+  root: string,
+  dir: string,
+  recursive: boolean = false,
+): Set<string> {
+  return new Set(
+    fs.readdirSync(path.join(root, dir), {
+      recursive,
+    }) as string[],
+  );
+}
+
+function readFile(root: string, file: string): string {
+  return fs.readFileSync(path.join(root, file), 'utf8');
+}
+
 beforeAll(async () => {
-  releasePath = fs.mkdtempSync('/tmp/wp-release-');
-  pluginConfig.releasePath = releasePath;
+  wDir = fs.mkdtempSync('/tmp/wp-release-');
+  pluginConfig.releasePath = wDir;
 });
 
 beforeEach(() => {
@@ -51,28 +77,30 @@ afterEach(async () => {
 });
 
 afterAll(async () => {
-  fs.removeSync(releasePath);
+  fs.removeSync(wDir);
 });
 
 describe('Publish step', () => {
-  it('Should package a complete plugin', async () => {
+  it('Should zip a complete plugin properly', async () => {
     await prepare(pluginConfig, contexts.publishContext);
     await publish(pluginConfig, contexts.publishContext);
 
-    const distFolder = fs
-      .readdirSync(path.join(releasePath, 'dist-test'))
-      .join(' ');
+    expect(readFile(path.join(wDir, 'dist-test'), 'readme.txt')).toMatch(
+      /^Stable tag: 1.0.0$/gm,
+    );
+    expect(readZip(wDir, 'package.zip', /^dist-test\//)).toEqual(
+      readDir(wDir, 'dist-test'),
+    );
+    expect(readZip(wDir, 'assets.zip')).toEqual(readDir(wDir, 'assets', true));
+    expect(readFile(wDir, 'VERSION')).toEqual('1.0.0');
 
-    expect(distFolder).not.toContain('node_modules');
-    expect(distFolder).toContain('vendor');
-    expect(distFolder).toContain('dist-test.php');
-    expect(distFolder).toContain('test1.php');
+    // expect readZip(releasePath, 'assets.zip');
   });
 
   it('Should should remove folders on success', async () => {
     await success(pluginConfig, contexts.publishContext);
 
-    const files = fs.readdirSync(releasePath).join(' ');
+    const files = fs.readdirSync(wDir).join(' ');
 
     expect(files).toContain('package.zip');
     expect(files).toContain('assets.zip');
@@ -85,7 +113,7 @@ describe('Publish step', () => {
     try {
       await prepare(pluginConfig, contexts.publishContext);
 
-      await fs.remove(path.join(releasePath, 'assets'));
+      await fs.remove(path.join(wDir, 'assets'));
       await publish(pluginConfig, contexts.publishContext);
     } catch (err) {
       expect((err as SemanticReleaseError).code).toMatch(/(ENOENT|EZIP)/);


### PR DESCRIPTION
Sorted out paths for wp-org asset files and blueprints.

Added `adm-zip` package for proper ZIP file testing.